### PR TITLE
removing permission block from manifests

### DIFF
--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -27,7 +27,6 @@
       "description": "Move active tab to right"
     }
   },
-  "permissions": ["tabs"],
   "icons": {
     "16": "icon16.png",
     "32": "icon32.png",

--- a/manifest.json
+++ b/manifest.json
@@ -30,7 +30,6 @@
   "browser_action": {
     "default_icon": "icon16.png"
   },
-  "permissions": ["tabs"],
   "icons": {
     "16": "icon16.png",
     "32": "icon32.png",


### PR DESCRIPTION
No permissions are needed to rearrange tabs (Issue #19). Extension works as intended without request the "tabs" permission from users.