### PR TITLE
#3: Add feature to move selected tabs to the front or the end of the tab bar

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,4 +1,9 @@
 
+2.1.0 / 2018-07-05
+==================
+
+  * Add feature to move tabs to the front or the end of the tab bar (Issue #3)
+
 2.0.0 / 2017-10-21
 ==================
 

--- a/README.md
+++ b/README.md
@@ -8,15 +8,25 @@ around using keyboard shortcuts.
 
 Rearrange Tabs has been featured on [LifeHacker](http://lifehacker.com/this-extension-rearranges-chrome-tabs-with-keyboard-sho-1791622486) and [Changelog](http://email.changelog.com/t/t-9A7FDF4C536D63BF) :smile:
 
-- To move a tab to its left
+- To move selected tab(s) left
 
   - `Mac`: <kbd>Ctrl</kbd>-<kbd>Shift</kbd>-<kbd>Left</kbd>
   - `Windows`: <kbd>Shift</kbd>-<kbd>Alt</kbd>-<kbd>Left</kbd>
 
-- To move a tab to its right
+- To move selected tab(s) right
 
   - `Mac`: <kbd>Ctrl</kbd>-<kbd>Shift</kbd>-<kbd>Right</kbd>
   - `Windows`: <kbd>Shift</kbd>-<kbd>Alt</kbd>-<kbd>Right</kbd>
+
+- To move selected tab(s) to the front (leftmost position)
+
+  - `Mac`: <kbd>Ctrl</kbd>-<kbd>Shift</kbd>-<kbd>Down</kbd>
+  - `Windows`: <kbd>Shift</kbd>-<kbd>Alt</kbd>-<kbd>Down</kbd>
+
+- To move selected tab(s) to the end (rightmost position)
+
+  - `Mac`: <kbd>Ctrl</kbd>-<kbd>Shift</kbd>-<kbd>Up</kbd>
+  - `Windows`: <kbd>Shift</kbd>-<kbd>Alt</kbd>-<kbd>Up</kbd>
 
 It's as simple as that. Here's how it looks like: [https://www.youtube.com/watch?v=A1X3geKtF8A](https://www.youtube.com/watch?v=A1X3geKtF8A)
 
@@ -57,6 +67,7 @@ Install the extension by visiting this Chrome Web Store link: **[Chrome Web Stor
 - Sandeep Appikonda (@appikonda)
 - Rob Yang (@unknownbreaker)
 - Roland Synnestvedt (@rsynnest)
+- Tomas Juočepis (@TomasJuocepis)
 
 ## License
 

--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Rearrange Tabs",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Allows users to rearrange tabs using keyboard shortcuts",
   "author": "Mohnish Thallavajhula",
   "manifest_version": 2,
@@ -10,21 +10,37 @@
     "persistent": false
   },
   "commands": {
-    "move-tab-left": {
+    "move-selected-tabs-left": {
       "suggested_key": {
         "default": "Shift+Alt+Left",
         "windows": "Shift+Alt+Left",
         "mac": "MacCtrl+Shift+Left"
       },
-      "description": "Move active tab to left"
+      "description": "Move selected tab(s) left"
     },
-    "move-tab-right": {
+    "move-selected-tabs-right": {
       "suggested_key": {
         "default": "Shift+Alt+Right",
         "windows": "Shift+Alt+Right",
         "mac": "MacCtrl+Shift+Right"
       },
-      "description": "Move active tab to right"
+      "description": "Move selected tab(s) right"
+    },
+    "move-selected-tabs-to-front": {
+      "suggested_key": {
+        "default": "Shift+Alt+Down",
+        "windows": "Shift+Alt+Down",
+        "mac": "MacCtrl+Shift+Down"
+      },
+      "description": "Move selected tab(s) to the front"
+    },
+    "move-selected-tabs-to-end": {
+      "suggested_key": {
+        "default": "Shift+Alt+Up",
+        "windows": "Shift+Alt+Up",
+        "mac": "MacCtrl+Shift+Up"
+      },
+      "description": "Move selected tab(s) to the end"
     }
   },
   "browser_action": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Rearrange Tabs",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Allows users to rearrange tabs using keyboard shortcuts",
   "author": "Mohnish Thallavajhula",
   "manifest_version": 2,
@@ -10,21 +10,37 @@
     "persistent": false
   },
   "commands": {
-    "move-tab-left": {
+    "move-selected-tabs-left": {
       "suggested_key": {
         "default": "Shift+Alt+Left",
         "windows": "Shift+Alt+Left",
         "mac": "MacCtrl+Shift+Left"
       },
-      "description": "Move active tab to left"
+      "description": "Move selected tab(s) left"
     },
-    "move-tab-right": {
+    "move-selected-tabs-right": {
       "suggested_key": {
         "default": "Shift+Alt+Right",
         "windows": "Shift+Alt+Right",
         "mac": "MacCtrl+Shift+Right"
       },
-      "description": "Move active tab to right"
+      "description": "Move selected tab(s) right"
+    },
+    "move-selected-tabs-to-front": {
+      "suggested_key": {
+        "default": "Shift+Alt+Down",
+        "windows": "Shift+Alt+Down",
+        "mac": "MacCtrl+Shift+Down"
+      },
+      "description": "Move selected tab(s) to the front"
+    },
+    "move-selected-tabs-to-end": {
+      "suggested_key": {
+        "default": "Shift+Alt+Up",
+        "windows": "Shift+Alt+Up",
+        "mac": "MacCtrl+Shift+Up"
+      },
+      "description": "Move selected tab(s) to the end"
     }
   },
   "browser_action": {


### PR DESCRIPTION
I noticed Issue #3 was closed as "wontfix", but here is my implementation of this feature, which I found to be useful and I think others might like it as well.

This introduces two new shortcuts using "Up" and "Down" keys in addition to the existing "Left" and "Right" keys. "Up" represents the "end" (rightmost boundary) while "Down" represents the "front" (leftmost boundary).

This works with pinned and unpinned tabs properly.